### PR TITLE
Improve gdb compatibility 

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -942,7 +942,7 @@ fromCDT (STATE *pstate, const char *commandLine, int linesize)			// from cdt
 	}
 	else if (strcmp(cc.argv[0],"catch")==0 && strcmp(cc.argv[1],"catch")==0) {
 		SBBreakpoint breakpoint = target.BreakpointCreateForException(lldb::LanguageType::eLanguageTypeC_plus_plus, true, false);
-		
+
 		cdtprintf ("&\"catch catch\\n\"\n");
 		cdtprintf ("~\"Catchpoint %d (catch)\\n\"\n", breakpoint.GetID());
 		cdtprintf ("=breakpoint-created,bkpt={number=\"%d\",type=\"breakpoint\",disp=\"keep\",enabled=\"y\",addr=\"<PENDING>\",what=\"exception catch\",catch-type=\"catch\",times=\"0\"}\n", breakpoint.GetID());
@@ -950,7 +950,7 @@ fromCDT (STATE *pstate, const char *commandLine, int linesize)			// from cdt
 	}
 	else if (strcmp(cc.argv[0],"catch")==0 && strcmp(cc.argv[1],"throw")==0) {
 		SBBreakpoint breakpoint = target.BreakpointCreateForException(lldb::LanguageType::eLanguageTypeC_plus_plus, false, true);
-		
+
 		cdtprintf ("&\"catch throw\\n\"\n");
 		cdtprintf ("~\"Catchpoint %d (throw)\\n\"\n", breakpoint.GetID());
 		cdtprintf ("=breakpoint-created,bkpt={number=\"%d\",type=\"breakpoint\",disp=\"keep\",enabled=\"y\",addr=\"<PENDING>\",what=\"exception throw\",catch-type=\"throw\",times=\"0\"}\n", breakpoint.GetID());
@@ -1007,7 +1007,12 @@ evalCDTCommand (STATE *pstate, const char *cdtcommand, CDT_COMMAND *cc)
 	if (cdtcommand[0] == '\0')	// just ENTER
 		return 0;
 	int fields = sscanf (cdtcommand, "%d%[^\0]", &cc->sequence, cc->arguments);
-	if (fields < 2) {
+	if (fields == 0) {
+		fields = sscanf (cdtcommand, "%[^\0]", cc->arguments);
+		if (fields != 1) return 0;
+		cc->sequence = 0;
+	}
+	else {
 		logprintf (LOG_WARN, "invalid command format: ");
 		logdata (LOG_NOHEADER, cdtcommand, strlen(cdtcommand));
 		cdtprintf ("%d^error,msg=\"%s\"\n(gdb)\n", cc->sequence, "invalid command format.");

--- a/src/lldbmi2.cpp
+++ b/src/lldbmi2.cpp
@@ -78,7 +78,7 @@ main (int argc, char **argv, char **envp)
 		logarg (argv[narg]);
 		if (strcmp (argv[narg],"--version") == 0)
 			isVersion = 1;
-		else if (strcmp (argv[narg],"--interpreter") == 0 ) {
+		else if (strcmp (argv[narg],"--interpreter") == 0 || strcmp (argv[narg],"--interpreter=mi2") == 0) {
 			isInterpreter = 1;
 			if (++narg<argc)
 				logarg(argv[narg]);


### PR DESCRIPTION
Allow `--interpreter=mi2` and allow omission of sequence number.

Closes #20 