### PR TITLE
use const char* to store output of SBStream.GetData

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -1097,7 +1097,7 @@ fromCDT (STATE *pstate, const char *commandLine, int linesize)			// from cdt
 						if (strcasecmp(valtype.GetName(), "char *") == 0) {
 							SBStream s;
 							val.GetDescription(s);
-							char *str = strchr(s.GetData(), '=');
+							const char *str = strchr(s.GetData(), '=');
 							str = str+2;
 							cdtprintf ("%d^done,value=\"%s\"\n(gdb)\n", cc.sequence, str);
 						}


### PR DESCRIPTION
Fixes:
```
ari@pibble:~/git/lldbmi2$./build.sh
-- The C compiler identification is AppleClang 9.1.0.9020039
-- The CXX compiler identification is AppleClang 9.1.0.9020039
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/ari/git/lldbmi2/build
Scanning dependencies of target lldbmi2
[ 10%] Building CXX object CMakeFiles/lldbmi2.dir/src/engine.cpp.o
/Users/ari/git/lldbmi2/src/engine.cpp:1100:14: error: cannot initialize a variable of type 'char *' with an rvalue of
      type 'const char *'
                                                        char *str = strchr(s.GetData(), '=');
                                                              ^     ~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
make[2]: *** [CMakeFiles/lldbmi2.dir/src/engine.cpp.o] Error 1
make[1]: *** [CMakeFiles/lldbmi2.dir/all] Error 2
make: *** [all] Error 2
```