### PR TITLE
Typo fixes

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -1791,11 +1791,11 @@ addEnvironment (STATE *pstate, const char *entrystring)
 	logprintf (LOG_NONE, "addEnvironment (0x%x, %s)\n", pstate, entrystring);
 	size_t entrysize = strlen (entrystring);
 	if (pstate->envpentries >= ENV_ENTRIES-2) {		// keep size for final NULL
-		logprintf (LOG_ERROR, "addEnvironement: envp size (%d) too small\n", sizeof(pstate->envs));
+		logprintf (LOG_ERROR, "addEnvironment: envp size (%d) too small\n", sizeof(pstate->envs));
 		return false;
 	}
 	if (pstate->envspointer-pstate->envs+1+entrysize >= sizeof(pstate->envs)) {
-		logprintf (LOG_ERROR, "addEnvironement: envs size (%d) too small\n", sizeof(pstate->envs));
+		logprintf (LOG_ERROR, "addEnvironment: envs size (%d) too small\n", sizeof(pstate->envs));
 		return false;
 	}
 	pstate->envp[pstate->envpentries++] = pstate->envspointer;

--- a/src/variables.cpp
+++ b/src/variables.cpp
@@ -10,9 +10,9 @@ extern LIMITS limits;
 
 // TODO: implement @ formats for structures like struct S. seems to be a bug in lldb
 bool
-getPeudoArrayVariable (SBFrame frame, const char *expression, SBValue &var)
+getPseudoArrayVariable (SBFrame frame, const char *expression, SBValue &var)
 {
-	logprintf (LOG_TRACE, "getPeudoArrayVariable (0x%x, %s, 0x%x)\n", &frame, expression, &var);
+	logprintf (LOG_TRACE, "getPseudoArrayVariable (0x%x, %s, 0x%x)\n", &frame, expression, &var);
 // just support *((var)+0)@100 and &(*((var)+0)@100) forms
 // char c[101];
 // -var-create * *((c)+0)@100
@@ -56,7 +56,7 @@ getPeudoArrayVariable (SBFrame frame, const char *expression, SBValue &var)
 	snprintf (newexpression, sizeof(newexpression), "%s*(%s[%s])&%s[%s]%s",	// (char(*)[100])&c[0] or &((char(*)[100])&c[0])
 			ampersand?"&(":"", newvartype, varlength, varname, varoffset, ampersand?")":"");
 	var = getVariable (frame, newexpression, false);
-	logprintf (LOG_DEBUG, "getPeudoArrayVariable: expression %s -> %s\n", expression, newexpression);
+	logprintf (LOG_DEBUG, "getPseudoArrayVariable: expression %s -> %s\n", expression, newexpression);
 	if (!var.IsValid() || var.GetError().Fail())
 		return false;
 	return true;
@@ -252,7 +252,7 @@ getVariable (SBFrame frame, const char *expression, bool tryDirect)
 	logprintf (LOG_TRACE, "getVariable (0x%x, %s)\n", &frame, expression);
 	SBValue var;
 	if (strchr(expression,'@') != NULL)
-		getPeudoArrayVariable (frame, expression, var);
+		getPseudoArrayVariable (frame, expression, var);
 	if ((!var.IsValid() || var.GetError().Fail()) && *expression=='$')
 		var = frame.FindRegister(expression);
 	if ((!var.IsValid() || var.GetError().Fail()) && tryDirect) {

--- a/src/variables.h
+++ b/src/variables.h
@@ -20,7 +20,7 @@ typedef enum
 
 #define min(a,b) ((a) < (b) ? (a) : (b))
 
-bool  getPeudoArrayVariable (SBFrame frame, const char *expression, SBValue &var);
+bool  getPseudoArrayVariable (SBFrame frame, const char *expression, SBValue &var);
 bool  getStandardPathVariable (SBFrame frame, const char *expression, SBValue &var);
 const char *getName ( SBValue &var);
 char *strfind (char *string, const char *find, int way=1, const char *except=NULL);

--- a/tests/scripts/largearray.log
+++ b/tests/scripts/largearray.log
@@ -834,7 +834,7 @@
 083803.174 >>=  |56-var-create --thread 1 --frame 0 - * *((ccc)+0)@100|
 083803.174 $$$  getVariable: expression=&ccc, name=&ccc, value=0x00007fff5fbff520, changed=0
 083803.177 $$$  getVariable: expression=*(char (*)[100])&ccc[0], name=$5, value=(null), changed=0
-083803.177 $$$  getPeudoArrayVariable: expression *((ccc)+0)@100 -> *(char (*)[100])&ccc[0]
+083803.177 $$$  getPseudoArrayVariable: expression *((ccc)+0)@100 -> *(char (*)[100])&ccc[0]
 083803.177 $$$  getVariable: expression=*((ccc)+0)@100, name=$5, value=(null), changed=0
 083803.177 $$$  updateVarState: Var=$5   : children=100, typeclass=Array     , basictype=Invalid   , bytesize=100, Pointee: typeclass=Invalid   , basictype=Invalid   , bytesize=0 
 083803.177 $$$  formatExpressionPath: expressionpathdesc=$5
@@ -847,7 +847,7 @@
 083803.178 >>=  |57-var-create --thread 1 --frame 0 - * *((ccc)+100)@2|
 083803.178 $$$  getVariable: expression=&ccc, name=&ccc, value=0x00007fff5fbff520, changed=0
 083803.181 $$$  getVariable: expression=*(char (*)[2])&ccc[100], name=$6, value=(null), changed=0
-083803.181 $$$  getPeudoArrayVariable: expression *((ccc)+100)@2 -> *(char (*)[2])&ccc[100]
+083803.181 $$$  getPseudoArrayVariable: expression *((ccc)+100)@2 -> *(char (*)[2])&ccc[100]
 083803.181 $$$  getVariable: expression=*((ccc)+100)@2, name=$6, value=(null), changed=0
 083803.181 $$$  updateVarState: Var=$6   : children=2 , typeclass=Array     , basictype=Invalid   , bytesize=2 , Pointee: typeclass=Invalid   , basictype=Invalid   , bytesize=0 
 083803.181 $$$  formatExpressionPath: expressionpathdesc=$6
@@ -860,7 +860,7 @@
 083803.192 >>=  |58-var-create --thread 1 --frame 0 - * &(*((ccc)+0)@100)|
 083803.192 $$$  getVariable: expression=&ccc, name=&ccc, value=0x00007fff5fbff520, changed=0
 083803.205 $$$  getVariable: expression=&(*(char (*)[100])&ccc[0]), name=$7, value=0x00007fff5fbff520, changed=0
-083803.205 $$$  getPeudoArrayVariable: expression &(*((ccc)+0)@100) -> &(*(char (*)[100])&ccc[0])
+083803.205 $$$  getPseudoArrayVariable: expression &(*((ccc)+0)@100) -> &(*(char (*)[100])&ccc[0])
 083803.205 $$$  getVariable: expression=&(*((ccc)+0)@100), name=$7, value=0x00007fff5fbff520, changed=0
 083803.205 $$$  updateVarState: Var=$7   : children=100, typeclass=Pointer   , basictype=Invalid   , bytesize=8 , Pointee: typeclass=Array     , basictype=Invalid   , bytesize=100
 083803.205 $$$  formatExpressionPath: expressionpathdesc=$7
@@ -1173,7 +1173,7 @@
 083803.222 >>=  |59-var-create --thread 1 --frame 0 - * &(*((ccc)+100)@2)|
 083803.223 $$$  getVariable: expression=&ccc, name=&ccc, value=0x00007fff5fbff520, changed=0
 083803.244 $$$  getVariable: expression=&(*(char (*)[2])&ccc[100]), name=$8, value=0x00007fff5fbff584, changed=0
-083803.244 $$$  getPeudoArrayVariable: expression &(*((ccc)+100)@2) -> &(*(char (*)[2])&ccc[100])
+083803.244 $$$  getPseudoArrayVariable: expression &(*((ccc)+100)@2) -> &(*(char (*)[2])&ccc[100])
 083803.244 $$$  getVariable: expression=&(*((ccc)+100)@2), name=$8, value=0x00007fff5fbff584, changed=0
 083803.244 $$$  updateVarState: Var=$8   : children=2 , typeclass=Pointer   , basictype=Invalid   , bytesize=8 , Pointee: typeclass=Array     , basictype=Invalid   , bytesize=2 
 083803.244 $$$  formatExpressionPath: expressionpathdesc=$8
@@ -1192,7 +1192,7 @@
 083804.057 >>=  |60-data-evaluate-expression --thread 1 --frame 0 *((ccc)+0)@100|
 083804.057 $$$  getVariable: expression=&ccc, name=&ccc, value=0x00007fff5fbff520, changed=0
 083804.060 $$$  getVariable: expression=*(char (*)[100])&ccc[0], name=$9, value=(null), changed=0
-083804.060 $$$  getPeudoArrayVariable: expression *((ccc)+0)@100 -> *(char (*)[100])&ccc[0]
+083804.060 $$$  getPseudoArrayVariable: expression *((ccc)+0)@100 -> *(char (*)[100])&ccc[0]
 083804.060 $$$  getVariable: expression=*((ccc)+0)@100, name=$9, value=(null), changed=0
 083804.060 $$$  formatValue: Var=$9   : children=100, typeclass=Array     , basictype=Invalid   , bytesize=100, Pointee: typeclass=Invalid   , basictype=Invalid   , bytesize=0 
 083804.060 $$$  formatSummary: Var=$9   : children=100, typeclass=Array     , basictype=Invalid   , bytesize=100, Pointee: typeclass=Invalid   , basictype=Invalid   , bytesize=0 


### PR DESCRIPTION
`getPeudoArrayVariable` -> `getPseudoArrayVariable` and `addEnvironement` -> `addEnvironment`