### PR TITLE
Fix loading symbols from `dlopen`-ed shared libraries when started from Eclipse

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -99,8 +99,8 @@ fromCDT (STATE *pstate, const char *commandLine, int linesize)			// from cdt
 		snprintf (path, sizeof(path), cc.argv[nextarg], pstate->project_loc);
 		if (strstr(cc.argv[nextarg],"%s")!=NULL)
 			logprintf (LOG_VARS, "%%s -> %s\n", path);
-		launchInfo.SetWorkingDirectory (path);
-		logprintf (LOG_NONE, "cwd=%s pwd=%s\n", path, launchInfo.GetWorkingDirectory());
+		chdir(path);
+		logprintf (LOG_NONE, "pwd=%s\n", path);
 		cdtprintf ("%d^done\n(gdb)\n", cc.sequence);
 	}
 	else if (strcmp(cc.argv[0],"unset")==0) {


### PR DESCRIPTION
By fixing the `"-environment-cd"` command, to make the debugger itself `chdir` into the given path, instead of only applying it to the launch info of the target to be spawned (if any).

This caused problems when the shared library was loaded by its relative path, and the debuggee was in a different working directory than the debugger, so using the same relative path didn't end up at the same shared library file for the two processes, making symbol loading fail.

This is what the documentation says should happen: https://sourceware.org/gdb/current/onlinedocs/gdb.html/GDB_002fMI-Program-Context.html#The-_002denvironment_002dcd-Command