### PR TITLE
Fix inspecting smart pointers

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -894,8 +894,6 @@ fromCDT (STATE *pstate, const char *commandLine, int linesize)			// from cdt
 						else
 							formatValue (vardescB, var, FULL_SUMMARY);		// was NO_SUMMARY
 						char *vardesc = vardescB.c_str();
-						if (vartype.IsReferenceType() && varnumchildren==1)	// correct numchildren and value if reference
-							--varnumchildren;
 						cdtprintf ("%d^done,name=\"%s\",numchild=\"%d\",value=\"%s\","
 							"type=\"%s\",thread-id=\"%d\",has_more=\"0\"\n(gdb)\n",
 							cc.sequence, expressionpathdesc, varnumchildren, vardesc,

--- a/src/variables.cpp
+++ b/src/variables.cpp
@@ -484,18 +484,6 @@ formatChangedList (StringB &changedescB, SBValue var, bool &separatorvisible, in
 	var.GetSummary();				// required to get value to activate changes
 	SBType vartype = var.GetType();
 	int varnumchildren = var.GetNumChildren();
-	if (vartype.IsReferenceType() && varnumchildren==1) {
-		// use child if reference. class (*) [] format
-		logprintf (LOG_DEBUG, "formatValue: special case class (*) []\n");
-		SBValue child = var.GetChildAtIndex(0);
-		if (child.IsValid() && var.GetError().Success()) {
-			child.SetPreferSyntheticValue (false);
-			var = child;
-			vartype = var.GetType();
-			varnumchildren = var.GetNumChildren();
-		}
-	}
-//	int varandchildrenchanged = updateVarState(var, limits.change_depth_max);
 	int varchanged = var.GetValueDidChange();
 	if (varchanged) {
 		const char *separator = separatorvisible? ",":"";
@@ -768,18 +756,6 @@ formatValue (StringB &vardescB, SBValue var, VariableDetails details)
 	logprintf (LOG_DEBUG, "formatValue: Var=%-5s: children=%-2d, typeclass=%-10s, basictype=%-10s, bytesize=%-2d, Pointee: typeclass=%-10s, basictype=%-10s, bytesize=%-2d\n",
 		getName(var), var.GetNumChildren(), getNameForTypeClass(vartype.GetTypeClass()), getNameForBasicType(vartype.GetBasicType()), vartype.GetByteSize(),
 		getNameForTypeClass(vartype.GetPointeeType().GetTypeClass()), getNameForBasicType(vartype.GetPointeeType().GetBasicType()), vartype.GetPointeeType().GetByteSize());
-	int varnumchildren = var.GetNumChildren();
-	if (vartype.IsReferenceType() && varnumchildren==1) {
-		// use child if reference. class (*) [] format
-		logprintf (LOG_DEBUG, "formatValue: special case class (*) []\n");
-		SBValue child = var.GetChildAtIndex(0);
-		if (child.IsValid() && var.GetError().Success()) {
-			child.SetPreferSyntheticValue (false);
-			var = child;
-			vartype = var.GetType();
-			varnumchildren = var.GetNumChildren();
-		}
-	}
 	const char *varname = getName(var);
 	static StringB summarydescB(BIG_LINE_MAX);
 	summarydescB.clear();								// clear previous buffer content


### PR DESCRIPTION
By removing the broken special case when listing children of reference type objects with one child, which tried to remove a level of indirection.

I'll admit that I'm tearing down one of Chesterton's fences here, as I don't understand exactly what was the original purpose of this "dereferencing" logic, I only know that it broke one of our use cases involving custom smart pointers.